### PR TITLE
Syphon Filter: The Omega Strain WS: Fixed Hud

### DIFF
--- a/cheats_ws/27E54B37.pnach
+++ b/cheats_ws/27E54B37.pnach
@@ -10,8 +10,8 @@ patch=1,EE,003972f0,word,46031840
 patch=1,EE,00397364,word,e603007c
 
 //HUD fix
-patch=1,EE,0039719c,word,00000000
-patch=1,EE,003971a4,word,3C033f40
+//patch=1,EE,0039719c,word,00000000
+//patch=1,EE,003971a4,word,3C033f40
 
 //FMV's fix
 patch=1,EE,00418f3c,word,241016d0

--- a/cheats_ws/3676E74C.pnach
+++ b/cheats_ws/3676E74C.pnach
@@ -10,8 +10,8 @@ patch=1,EE,0039a7e0,word,46031840
 patch=1,EE,0039a854,word,e603007c
 
 //HUD fix (0500c310 5500013c 803f033c)
-patch=1,EE,0039a68c,word,00000000
-patch=1,EE,0039a694,word,3C033f40
+//patch=1,EE,0039a68c,word,00000000
+//patch=1,EE,0039a694,word,3C033f40
 
 //FMV's fix
 patch=1,EE,0041cba4,word,24126c00 //24127100

--- a/cheats_ws/D5605611.pnach
+++ b/cheats_ws/D5605611.pnach
@@ -10,8 +10,8 @@ patch=1,EE,003754f0,word,46031840
 patch=1,EE,00375564,word,e603007c
 
 //HUD fix
-patch=1,EE,0037539c,word,00000000
-patch=1,EE,003753a4,word,3C033f40
+//patch=1,EE,0037539c,word,00000000
+//patch=1,EE,003753a4,word,3C033f40
 
 //FMV's fix
 patch=1,EE,003F752c,word,24101400


### PR DESCRIPTION
The game in question is "Syphon Filter: the Omega Strain" it has 3 versions:
-USA (NTSC-U)
-Europe/Australia (PAL)
-Korea (NTSC-K)
So that makes them 3 widescreen pnachs, they are all included in the cheats_ws.zip of PCSX2 1.6 and 1.7 the nightly build, but they are faulty, i did the right adjustments and i want the correct form of the pnachs to be included inside cheats_ws.zip in future updates (at least the regular nightly build updates).

The widescreen patch for each version is 3 fold, Gameplay, Hud, & FMV. The gameplay and FMV worked correctly already, but the HUD elements like radar and weapon icon are not on the edges of the screen, they are actually 4:3 and are placed in the center of the screen when the HUD patch is active, while everything else is in 16:9 widescreen, so the simple fix is disable the HUD patch only (i put 2 slashes before the HUD patch lines), which would place the HUD correctly, and the scope first person camera now won't have black bars, and finally the menu won't have black bars.